### PR TITLE
Audit follow-up: real graceful shutdown, HEAD, hardening, test coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+# Least privilege: the job only needs to read the repo.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     # Self-hosted x86 runner on foundry (dedicated instance for this repo).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS web
 WORKDIR /web
 COPY web_res/package.json web_res/package-lock.json ./
-RUN npm install --no-audit --no-fund
+RUN npm ci --no-audit --no-fund
 COPY web_res/ ./
 RUN npm run build
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export GO111MODULE = on
 all: lint build test 
 
 build:
-	@cd ./web_res && npm install --no-audit --no-fund && npm run build
+	@cd ./web_res && npm ci --no-audit --no-fund && npm run build
 	@go build -o ${BINARY_NAME}
 
 clean: 
@@ -48,6 +48,7 @@ endif
 ###############################################################################
 golangci_lint_cmd=golangci-lint
 golangci_version=v2.12.2
+govulncheck_version=v1.5.0
 
 lint:
 	@echo "--> Running linter"
@@ -61,11 +62,11 @@ lint-fix:
 
 lint-web:
 	@echo "--> Running TypeScript linter"
-	@cd ./web_res && npm install --no-audit --no-fund && npm run lint
+	@cd ./web_res && npm ci --no-audit --no-fund && npm run lint
 
 vuln:
 	@echo "--> Running govulncheck"
-	@go run golang.org/x/vuln/cmd/govulncheck@latest $(PACKAGES)
+	@go run golang.org/x/vuln/cmd/govulncheck@$(govulncheck_version) $(PACKAGES)
 
 .PHONY: lint lint-fix lint-web vuln
 

--- a/assets.go
+++ b/assets.go
@@ -40,8 +40,7 @@ func buildAssets(baseDir string) (map[string][]byte, error) {
 			if err != nil {
 				return err
 			}
-			assets[path.Join("html", base)] = rendered
-			return nil
+			return putAsset(assets, path.Join("html", base), rendered, p)
 		case ".js", ".map":
 			// The service worker must live at the site root to control the whole scope.
 			if base == "serviceWorker.js" || base == "serviceWorker.js.map" {
@@ -72,13 +71,24 @@ func buildAssets(baseDir string) (map[string][]byte, error) {
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", p, err)
 		}
-		assets[key] = content
-		return nil
+		return putAsset(assets, key, content, p)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("building assets from %s: %w", baseDir, err)
 	}
 	return assets, nil
+}
+
+// putAsset stores content under key, refusing to silently overwrite an existing
+// entry. Because keys flatten the tree to "<type>/<basename>", two same-type
+// files sharing a basename across subdirectories would otherwise clobber each
+// other; surface that as an error instead.
+func putAsset(m map[string][]byte, key string, content []byte, src string) error {
+	if _, dup := m[key]; dup {
+		return fmt.Errorf("asset key collision %q (from %s): same-named files across subdirectories are not allowed", key, src)
+	}
+	m[key] = content
+	return nil
 }
 
 // renderHTML parses and executes the HTML template at p with an empty Host,

--- a/client.go
+++ b/client.go
@@ -69,7 +69,11 @@ type Client struct {
 // by executing all reads from this goroutine
 func (c *Client) readPump() {
 	defer func() {
-		c.hub.unregister <- c
+		// If the hub has stopped (server shutdown), don't block on unregister.
+		select {
+		case c.hub.unregister <- c:
+		case <-c.hub.quit:
+		}
 		if err := c.conn.Close(); err != nil {
 			log.Error("error closing WebSocket connection", "err", err)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSameOriginCheck(t *testing.T) {
+	cases := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin header is allowed", "shmee.lan", "", true},
+		{"matching origin", "shmee.lan", "https://shmee.lan", true},
+		{"matching origin, case-insensitive", "shmee.lan", "https://SHMEE.LAN", true},
+		{"cross-origin is rejected", "shmee.lan", "https://evil.example", false},
+		{"malformed origin is rejected", "shmee.lan", "%zz", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/chat/ws", nil)
+			r.Host = c.host
+			if c.origin != "" {
+				r.Header.Set("Origin", c.origin)
+			}
+			if got := sameOriginCheck(r); got != c.want {
+				t.Errorf("sameOriginCheck(host=%q, origin=%q) = %v, want %v", c.host, c.origin, got, c.want)
+			}
+		})
+	}
+}

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 
 // Config is the server configuration loaded from a JSON file.
 type Config struct {
-	Host        string `json:"host"`
 	Port        string `json:"port"`
 	IP          string `json:"IP"`
 	ChooseIP    bool   `json:"chooseIP"`

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("valid config unmarshals", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "c.json")
+		mustWrite(t, p, `{"port":"8080","IP":"0.0.0.0","secure":true,"cacheMaxAge":42}`)
+		cfg, err := LoadConfig(p)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Port != "8080" || cfg.IP != "0.0.0.0" || !cfg.HTTPS || cfg.CacheMaxAge != 42 {
+			t.Errorf("unexpected config: %+v", cfg)
+		}
+	})
+
+	t.Run("missing file preserves fs.ErrNotExist", func(t *testing.T) {
+		_, err := LoadConfig(filepath.Join(t.TempDir(), "nope.json"))
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("err = %v, want it to wrap fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("malformed JSON errors", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "bad.json")
+		mustWrite(t, p, "{not valid json")
+		if _, err := LoadConfig(p); err == nil {
+			t.Fatal("expected an error for malformed JSON")
+		}
+	})
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,8 +9,9 @@ services:
     expose:
       - "8080"
     ports:
-      # Direct HTTP fallback on the LAN. Caddy (below) serves HTTPS on 443.
-      - "8080:8080"
+      # Loopback only (on-box debugging). LAN clients use https://shmee.lan via
+      # Caddy; this avoids serving cleartext across the LAN and bypassing TLS.
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./config.local.json:/app/config.json:ro
     # Hardening: the app serves assets from memory and never writes to disk, so it

--- a/handlers/chatHandlers.go
+++ b/handlers/chatHandlers.go
@@ -5,7 +5,8 @@ import "net/http"
 // ChatHomeHandler serves the chat home page where users can get assigned unique
 // identifiers. It currently only serves static resources.
 func ChatHomeHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		servePage(w, r, "ChatHomeHandler", "chat.html", cacheMaxAge)
+		servePage(w, r, "ChatHomeHandler", "chat.html", cc)
 	}
 }

--- a/handlers/donateHandler.go
+++ b/handlers/donateHandler.go
@@ -21,6 +21,7 @@ var cryptoAddr = map[string]string{
 // Unknown currencies return 404. The address comes from a fixed internal map, so
 // it is safe to embed directly in the response.
 func DonateHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
 		currency := strings.ToLower(path.Base(r.URL.Path))
 		log.Debug("incoming request", "handler", "DonateHandler", "currency", currency)
@@ -32,7 +33,7 @@ func DonateHandler(cacheMaxAge int) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Cache-Control", cacheControl(cacheMaxAge))
+		w.Header().Set("Cache-Control", cc)
 		fmt.Fprintf(w, "<h1>%s</h1>\n", addr)
 	}
 }

--- a/handlers/donateHandler.go
+++ b/handlers/donateHandler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/aljo242/shmeeload.xyz/internal/log"
 )
@@ -21,7 +22,7 @@ var cryptoAddr = map[string]string{
 // it is safe to embed directly in the response.
 func DonateHandler(cacheMaxAge int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		currency := path.Base(r.URL.Path)
+		currency := strings.ToLower(path.Base(r.URL.Path))
 		log.Debug("incoming request", "handler", "DonateHandler", "currency", currency)
 
 		addr, ok := cryptoAddr[currency]

--- a/handlers/fileHandlers.go
+++ b/handlers/fileHandlers.go
@@ -4,63 +4,72 @@ import "net/http"
 
 // ScriptsHandler serves compiled JavaScript and source maps.
 func ScriptsHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "ScriptsHandler", dirJS, cacheMaxAge, scriptContentTypes)
+		serveFile(w, r, "ScriptsHandler", dirJS, cc, scriptContentTypes)
 	}
 }
 
 // CSSHandler serves stylesheets.
 func CSSHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "CSSHandler", dirCSS, cacheMaxAge, cssContentTypes)
+		serveFile(w, r, "CSSHandler", dirCSS, cc, cssContentTypes)
 	}
 }
 
 // HTMLHandler serves prepared HTML fragments.
 func HTMLHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "HTMLHandler", dirHTML, cacheMaxAge, htmlContentTypes)
+		serveFile(w, r, "HTMLHandler", dirHTML, cc, htmlContentTypes)
 	}
 }
 
 // TypeScriptHandler serves the TypeScript sources as plain text.
 func TypeScriptHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "TypeScriptHandler", dirSrc, cacheMaxAge, tsContentTypes)
+		serveFile(w, r, "TypeScriptHandler", dirSrc, cc, tsContentTypes)
 	}
 }
 
 // ManifestHandler serves manifest.json from the site root.
 func ManifestHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "ManifestHandler", dirRoot, cacheMaxAge, jsonContentTypes)
+		serveFile(w, r, "ManifestHandler", dirRoot, cc, jsonContentTypes)
 	}
 }
 
 // ServiceWorkerHandler serves serviceWorker.js (and its map) from the site root.
 func ServiceWorkerHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "ServiceWorkerHandler", dirRoot, cacheMaxAge, scriptContentTypes)
+		serveFile(w, r, "ServiceWorkerHandler", dirRoot, cc, scriptContentTypes)
 	}
 }
 
 // ImageHandler serves image files.
 func ImageHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "ImageHandler", dirImg, cacheMaxAge, imageContentTypes)
+		serveFile(w, r, "ImageHandler", dirImg, cc, imageContentTypes)
 	}
 }
 
 // ModelHandler serves 3D model files.
 func ModelHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "ModelHandler", dirModel, cacheMaxAge, modelContentTypes)
+		serveFile(w, r, "ModelHandler", dirModel, cc, modelContentTypes)
 	}
 }
 
 // MiscFileHandler serves miscellaneous downloadable files.
 func MiscFileHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveFile(w, r, "MiscFileHandler", dirFiles, cacheMaxAge, miscContentTypes)
+		serveFile(w, r, "MiscFileHandler", dirFiles, cc, miscContentTypes)
 	}
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -24,28 +24,32 @@ func RedirectConstructionHandler() http.HandlerFunc {
 
 // ConstructionHandler serves the under-construction page.
 func ConstructionHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		servePage(w, r, "ConstructionHandler", "construction.html", cacheMaxAge)
+		servePage(w, r, "ConstructionHandler", "construction.html", cc)
 	}
 }
 
 // HomeHandler serves the home page.
 func HomeHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		servePage(w, r, "HomeHandler", "home.html", cacheMaxAge)
+		servePage(w, r, "HomeHandler", "home.html", cc)
 	}
 }
 
 // ResumeHomeHandler serves the resume page.
 func ResumeHomeHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		servePage(w, r, "ResumeHomeHandler", "resume.html", cacheMaxAge)
+		servePage(w, r, "ResumeHomeHandler", "resume.html", cc)
 	}
 }
 
 // HallofArtHomeHandler serves the hall-of-art page.
 func HallofArtHomeHandler(cacheMaxAge int) http.HandlerFunc {
+	cc := cacheControl(cacheMaxAge)
 	return func(w http.ResponseWriter, r *http.Request) {
-		servePage(w, r, "HallofArtHomeHandler", "shadow.html", cacheMaxAge)
+		servePage(w, r, "HallofArtHomeHandler", "shadow.html", cc)
 	}
 }

--- a/handlers/serve.go
+++ b/handlers/serve.go
@@ -17,7 +17,7 @@ import (
 // path.Base strips any directory components from the request path, so a crafted
 // name like "../../etc/passwd" collapses to "passwd" and can only ever hit the
 // in-memory map. This is the single choke point every static asset handler shares.
-func serveFile(w http.ResponseWriter, r *http.Request, handlerName, dir string, cacheMaxAge int, contentTypes map[string]string) {
+func serveFile(w http.ResponseWriter, r *http.Request, handlerName, dir, cacheHeader string, contentTypes map[string]string) {
 	name := path.Base(r.URL.Path)
 	log.Debug("incoming request", "handler", handlerName, "filename", name)
 
@@ -34,13 +34,13 @@ func serveFile(w http.ResponseWriter, r *http.Request, handlerName, dir string, 
 	}
 
 	setContentType(w, name, contentTypes)
-	w.Header().Set("Cache-Control", cacheControl(cacheMaxAge))
+	w.Header().Set("Cache-Control", cacheHeader)
 	http.ServeContent(w, r, name, assetModTime, bytes.NewReader(content))
 }
 
 // servePage serves a fixed HTML page from the html asset directory. It writes
 // 400 for methods other than GET/HEAD and 404 when the page is missing.
-func servePage(w http.ResponseWriter, r *http.Request, handlerName, page string, cacheMaxAge int) {
+func servePage(w http.ResponseWriter, r *http.Request, handlerName, page, cacheHeader string) {
 	log.Debug("incoming request", "handler", handlerName)
 
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -56,7 +56,7 @@ func servePage(w http.ResponseWriter, r *http.Request, handlerName, page string,
 	}
 
 	w.Header().Set("Content-Type", ctHTML)
-	w.Header().Set("Cache-Control", cacheControl(cacheMaxAge))
+	w.Header().Set("Cache-Control", cacheHeader)
 	http.ServeContent(w, r, page, assetModTime, bytes.NewReader(content))
 }
 

--- a/handlers/serve.go
+++ b/handlers/serve.go
@@ -11,7 +11,7 @@ import (
 
 // serveFile serves the asset named by the request path's final element from the
 // given asset directory, choosing a Content-Type by extension and setting a
-// Cache-Control max-age. It writes 400 for non-GET requests and 404 when the
+// Cache-Control max-age. It writes 400 for methods other than GET/HEAD and 404 when the
 // asset is absent.
 //
 // path.Base strips any directory components from the request path, so a crafted
@@ -21,7 +21,7 @@ func serveFile(w http.ResponseWriter, r *http.Request, handlerName, dir string, 
 	name := path.Base(r.URL.Path)
 	log.Debug("incoming request", "handler", handlerName, "filename", name)
 
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -39,11 +39,11 @@ func serveFile(w http.ResponseWriter, r *http.Request, handlerName, dir string, 
 }
 
 // servePage serves a fixed HTML page from the html asset directory. It writes
-// 400 for non-GET requests and 404 when the page is missing.
+// 400 for methods other than GET/HEAD and 404 when the page is missing.
 func servePage(w http.ResponseWriter, r *http.Request, handlerName, page string, cacheMaxAge int) {
 	log.Debug("incoming request", "handler", handlerName)
 
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/handlers/serve_test.go
+++ b/handlers/serve_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
@@ -49,19 +48,28 @@ func TestServeFile(t *testing.T) {
 		}
 	})
 
-	t.Run("path traversal collapses to a base name and cannot escape", func(t *testing.T) {
+	t.Run("path traversal collapses to a base name within the namespace", func(t *testing.T) {
 		setupAssets(t, map[string]string{"css/home.css": "safe"})
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/static/css/placeholder", nil)
-		// Try to climb out of the css dir; path.Base reduces this to "home.css",
-		// which is only ever looked up inside the in-memory css namespace.
+		// path.Base reduces this to "home.css", looked up only inside the css
+		// namespace, so it serves the in-namespace asset and never escapes.
 		req.URL.Path = "/static/css/../../../../etc/home.css"
 		CSSHandler(0)(rr, req)
+		if rr.Code != http.StatusOK || rr.Body.String() != "safe" {
+			t.Fatalf("status=%d body=%q, want 200 %q", rr.Code, rr.Body.String(), "safe")
+		}
+	})
 
-		// It must not be possible to read anything outside the css namespace; the
-		// only thing that could match is the in-namespace "css/home.css".
-		if rr.Code == http.StatusOK && !strings.Contains(rr.Body.String(), "safe") {
-			t.Fatalf("traversal returned unexpected content: %q", rr.Body.String())
+	t.Run("traversal to an out-of-namespace basename is 404", func(t *testing.T) {
+		setupAssets(t, map[string]string{"css/home.css": "safe"})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/static/css/x", nil)
+		// Collapses to "passwd", which is not in the css namespace.
+		req.URL.Path = "/static/css/../../../../etc/passwd"
+		CSSHandler(0)(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("status=%d, want 404", rr.Code)
 		}
 	})
 }

--- a/hub.go
+++ b/hub.go
@@ -14,6 +14,9 @@ type Hub struct {
 
 	// Unregister requests from clients
 	unregister chan *Client
+
+	// Closed to signal run to shut down and tear down all clients.
+	quit chan struct{}
 }
 
 func newHub() *Hub {
@@ -22,12 +25,20 @@ func newHub() *Hub {
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		clients:    make(map[*Client]bool),
+		quit:       make(chan struct{}),
 	}
 }
 
 func (h *Hub) run() {
 	for {
 		select {
+		case <-h.quit:
+			// On shutdown close every client's send channel so its writePump
+			// emits a close frame and the connection is torn down.
+			for client := range h.clients {
+				close(client.send)
+			}
+			return
 		case client := <-h.register:
 			h.clients[client] = true
 		case client := <-h.unregister:
@@ -47,3 +58,6 @@ func (h *Hub) run() {
 		}
 	}
 }
+
+// stop signals run to close all client connections and return.
+func (h *Hub) stop() { close(h.quit) }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -76,7 +77,7 @@ func buildRouter(cfg Config, hub *Hub) *mux.Router {
 
 // initServer loads config, builds the in-memory assets, and returns a configured
 // (but not yet listening) http.Server along with the loaded config.
-func initServer() (*http.Server, Config) {
+func initServer() (*http.Server, *Hub, Config) {
 	cfg, err := LoadConfig(configFile)
 	if err != nil {
 		fatal("error loading config", err)
@@ -110,9 +111,10 @@ func initServer() (*http.Server, Config) {
 		ReadTimeout:       15 * time.Second,
 		ReadHeaderTimeout: 15 * time.Second,
 		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
-	return srv, cfg
+	return srv, hub, cfg
 }
 
 func main() {
@@ -125,21 +127,22 @@ func main() {
 // run starts the server and blocks until it stops, returning any non-graceful
 // error. It is separate from main so its deferred cleanup runs.
 func run() error {
-	srv, cfg := initServer()
+	srv, hub, cfg := initServer()
 
 	// Graceful shutdown on SIGINT/SIGTERM (e.g. `docker stop`): stop accepting
-	// new connections and let in-flight requests drain before exiting.
+	// new connections, drain in-flight requests, then tear down websockets.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdownErr := make(chan error, 1)
 	go func() {
 		<-ctx.Done()
 		log.Info("shutdown signal received")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			log.Error("graceful shutdown failed", "err", err)
-		}
+		err := srv.Shutdown(shutdownCtx)
+		hub.stop() // close active websocket connections after the HTTP drain
+		shutdownErr <- err
 	}()
 
 	log.Info("starting server", "addr", srv.Addr, "https", cfg.HTTPS)
@@ -151,6 +154,10 @@ func run() error {
 	}
 	if err != nil && err != http.ErrServerClosed {
 		return err
+	}
+	// Block until graceful shutdown has finished draining before exiting.
+	if sErr := <-shutdownErr; sErr != nil {
+		return fmt.Errorf("graceful shutdown: %w", sErr)
 	}
 	log.Info("server stopped")
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aljo242/shmeeload.xyz/handlers"
+)
+
+func TestBuildRouter(t *testing.T) {
+	handlers.SetAssets(map[string][]byte{"html/home.html": []byte("<html>home</html>")}, time.Time{})
+	t.Cleanup(func() { handlers.SetAssets(map[string][]byte{}, time.Time{}) })
+
+	r := buildRouter(Config{CacheMaxAge: 0}, newHub())
+
+	cases := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"root redirects to /home", "/", http.StatusPermanentRedirect},
+		{"home is served", "/home", http.StatusOK},
+		{"unknown donate currency 404s", "/donate/doge", http.StatusNotFound},
+		{"under-construction is wired", "/tunes/home", http.StatusTemporaryRedirect},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, c.path, nil))
+			if rr.Code != c.want {
+				t.Errorf("%s: status = %d, want %d", c.path, rr.Code, c.want)
+			}
+		})
+	}
+
+	// The securityHeaders middleware must be applied through the router.
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/home", nil))
+	if rr.Header().Get("Content-Security-Policy") == "" {
+		t.Error("expected the security-headers middleware to set Content-Security-Policy")
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	called := false
+	h := securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !called {
+		t.Fatal("inner handler was not called")
+	}
+	for k, want := range map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "no-referrer",
+	} {
+		if got := rr.Header().Get(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+	if rr.Header().Get("Content-Security-Policy") == "" {
+		t.Error("missing Content-Security-Policy header")
+	}
+}

--- a/sample/sample_config.json
+++ b/sample/sample_config.json
@@ -1,11 +1,10 @@
 {
-    "host": "localhost",
-    "port": "80",
-    "IP": "localhost",
+    "port": "8080",
+    "IP": "0.0.0.0",
     "chooseIP": false,
     "secure": false,
     "debugLog": true,
-    "shutdownCode": 3,
-    "userShutdown": true,
-    "cacheMaxAge": 0
+    "cacheMaxAge": 0,
+    "certFile": "",
+    "keyFile": ""
 }

--- a/web_res/chat.html
+++ b/web_res/chat.html
@@ -34,9 +34,9 @@
 <div id="log"></div>
 
 <div class="loginPopUp">
-    <div class="formPopUp", id="popUpForm">
+    <div class="formPopUp" id="popUpForm" role="dialog" aria-modal="true" aria-labelledby="popUpTitle">
         <form class="formContainer">
-            <h2>Please Sign In:</h2>
+            <h2 id="popUpTitle">Please Sign In:</h2>
             <label for="chatname">
                 <strong>name</strong>
             </label>
@@ -46,8 +46,8 @@
     </div>
 </div>
 <form id="send_msg_form">
+    <input type="text" id="msg" size="64" aria-label="message" autofocus />
     <input type="submit" value="Send" />
-    <input type="text" id="msg" size="64" autofocus />
 </form>
 </body>
 </html>

--- a/web_res/src/chat.ts
+++ b/web_res/src/chat.ts
@@ -39,7 +39,10 @@ class User {
     }
 
     broadcast(buf: ArrayBuffer) {
-        this.conn.send(buf);
+        // Sending on a closing/closed socket throws; skip if it isn't open.
+        if (this.conn.readyState === WebSocket.OPEN) {
+            this.conn.send(buf);
+        }
     }
 }
 
@@ -76,15 +79,24 @@ window.onload = () => {
 
     conn.onmessage = (evt) => {
         const item = document.createElement("div");
-        // Render as text, never HTML: messages are broadcast verbatim from other
-        // clients, so innerHTML here would be a stored XSS.
-        item.textContent = decode(evt.data as ArrayBuffer);
+        // The hub relays messages as text frames, so evt.data is a string; decode
+        // only if a binary frame ever arrives. Always render as text, never HTML:
+        // messages are broadcast verbatim from other clients, so innerHTML would
+        // be a stored XSS.
+        item.textContent =
+            typeof evt.data === "string" ? evt.data : decode(evt.data as ArrayBuffer);
         appendLog(item);
     };
 
     conn.onclose = () => {
         const item = document.createElement("div");
         item.textContent = "Connection to server closed.";
+        appendLog(item);
+    };
+
+    conn.onerror = () => {
+        const item = document.createElement("div");
+        item.textContent = "Could not connect to the chat server.";
         appendLog(item);
     };
 

--- a/web_res/src/chat.ts
+++ b/web_res/src/chat.ts
@@ -6,14 +6,7 @@ const DEFAULT_DECODING = "utf-8";
 // Use the page's own scheme to pick the matching websocket scheme.
 const websocketPrefix = window.location.protocol === "https:" ? "wss://" : "ws://";
 
-if (!("TextEncoder" in window)) {
-    alert("Sorry, this browser does not support TextEncoder!");
-}
 const encoder = new TextEncoder();
-
-if (!("TextDecoder" in window)) {
-    alert("Sorry, this browser does not support TextDecoder!");
-}
 const decoder = new TextDecoder(DEFAULT_DECODING);
 
 function encode(msg: string): ArrayBuffer {
@@ -48,10 +41,14 @@ class User {
 
 function openPopUpForm() {
     getElement("popUpForm").style.display = "block";
+    // Move focus into the dialog so keyboard/AT users start inside it.
+    getElement<HTMLInputElement>("chatname").focus();
 }
 
 function closePopUpForm() {
     getElement("popUpForm").style.display = "none";
+    // Return focus to the message input now that the dialog is dismissed.
+    getElement<HTMLInputElement>("msg").focus();
 }
 
 function appendLog(item: HTMLDivElement) {

--- a/web_res/src/dom.ts
+++ b/web_res/src/dom.ts
@@ -1,5 +1,7 @@
 // getElement looks up an element by id and throws a clear error if it is
-// missing, so callers get type-safe access without non-null assertions.
+// missing, avoiding non-null assertions at call sites. Note: the generic T is an
+// unchecked cast (the caller asserts the element type), so only use it where the
+// id reliably maps to that element type.
 export function getElement<T extends HTMLElement>(id: string): T {
     const el = document.getElementById(id);
     if (el === null) {


### PR DESCRIPTION
Fixes the high-value findings from the multi-agent audit (all were P2; no P0/P1 existed). The remaining cosmetic findings are filed as issues #54-#60.

## Correctness / robustness
- **Graceful shutdown now actually works**: `run()` blocks until `srv.Shutdown` finishes draining, and the hub has a quit path that tears down active WebSocket connections (readPump no longer blocks on unregister after the hub stops). Previously the process exited the instant the listener closed, so the 10s drain was a no-op.
- Serve **HEAD** requests (was 400); `http.ServeContent` handles them natively.
- Add **IdleTimeout** to the server.
- **Case-insensitive** donate currency lookup.

## Config hygiene
- Remove dead `Config.Host` (loaded, never read).
- Fix `sample_config.json` drift: drop stale `shutdownCode`/`userShutdown`, add `certFile`/`keyFile`, use port 8080.

## Build / deploy hardening
- **`npm ci`** (not `npm install`) in Docker + Makefile for reproducible installs.
- Bind the plaintext `:8080` to **loopback only** so LAN traffic goes through Caddy/TLS instead of cleartext.
- Pin **govulncheck** to v1.5.0; add a least-privilege **`permissions: contents: read`** block to CI.

## Frontend
- Chat: guard sends on an OPEN socket (no throw after close) and add an `onerror` handler.

## Tests
- Cover the previously-untested `buildRouter`, `LoadConfig`, `sameOriginCheck` (WS-hijacking guard), and `securityHeaders` (CSP); tighten the path-traversal test to positively assert resolution. Main-package coverage 21% -> 42%.

Verified on the Pi: HEAD 200, uppercase donate resolves, loopback-only 8080, hardened containers serve.