### PR TITLE
Add abuse controls for public exposure

### DIFF
--- a/chat_test.go
+++ b/chat_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newChatTestServer spins up the real router (with the abuse-control middleware
+// and the chat hub) over httptest's loopback listener.
+func newChatTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	hub := newHub()
+	go hub.run()
+	site, err := newStaticSite(fstest.MapFS{}, 60)
+	if err != nil {
+		t.Fatalf("newStaticSite: %v", err)
+	}
+	srv := httptest.NewServer(buildRouter(Config{Port: "0"}, hub, site))
+	t.Cleanup(func() {
+		srv.Close()
+		hub.stop()
+	})
+	return srv
+}
+
+func wsURL(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + "/chat/ws"
+}
+
+func TestWebSocketConnectionCap(t *testing.T) {
+	srv := newChatTestServer(t)
+	url := wsURL(srv)
+
+	// Hold the maximum number of connections open for one IP (the loopback).
+	conns := make([]*websocket.Conn, 0, wsMaxPerIP)
+	for i := 0; i < wsMaxPerIP; i++ {
+		c, _, err := websocket.DefaultDialer.Dial(url, nil)
+		if err != nil {
+			t.Fatalf("dial %d should succeed: %v", i+1, err)
+		}
+		conns = append(conns, c)
+	}
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+
+	// The next connection from the same IP must be rejected before upgrade.
+	_, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err == nil {
+		t.Fatal("the over-cap connection should have been rejected")
+	}
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("over-cap status = %v, want 429", resp)
+	}
+}
+
+func TestWebSocketEcho(t *testing.T) {
+	srv := newChatTestServer(t)
+	c, _, err := websocket.DefaultDialer.Dial(wsURL(srv), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Let the hub finish registering this client before broadcasting.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := c.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := c.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(msg) != "hello" {
+		t.Errorf("echoed %q, want \"hello\"", msg)
+	}
+}
+
+func TestWebSocketMessageRateLimit(t *testing.T) {
+	srv := newChatTestServer(t)
+	c, _, err := websocket.DefaultDialer.Dial(wsURL(srv), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	time.Sleep(100 * time.Millisecond) // registered
+
+	// Flood far past the per-connection rate; most should be dropped.
+	const sent = 40
+	for i := 0; i < sent; i++ {
+		if err := c.WriteMessage(websocket.TextMessage, []byte("m")); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	if err := c.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	got := 0
+	for {
+		_, msg, err := c.ReadMessage()
+		if err != nil {
+			break // read deadline reached: we have drained what was broadcast
+		}
+		got += bytes.Count(msg, []byte("m")) // writePump batches messages with newlines
+	}
+	if got == 0 {
+		t.Error("expected at least the burst to get through")
+	}
+	if got > wsMsgBurst+5 {
+		t.Errorf("received %d messages from a flood of %d; rate limit did not drop enough", got, sent)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aljo242/shmeeload.xyz/internal/log"
 	"github.com/gorilla/websocket"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -60,6 +61,14 @@ type Client struct {
 
 	// Buffered channel of outbound messages
 	send chan []byte
+
+	// ip and conns release this connection's slot in the per-IP/global cap when
+	// the connection closes.
+	ip    string
+	conns *connLimiter
+
+	// msgLimiter throttles inbound chat messages from this connection.
+	msgLimiter *rate.Limiter
 }
 
 // readPump pumps messages from the websocket connection to the hub.
@@ -74,6 +83,7 @@ func (c *Client) readPump() {
 		case c.hub.unregister <- c:
 		case <-c.hub.quit:
 		}
+		c.conns.release(c.ip)
 		if err := c.conn.Close(); err != nil {
 			log.Error("error closing WebSocket connection", "err", err)
 		}
@@ -94,6 +104,13 @@ func (c *Client) readPump() {
 				log.Error("unexpected websocket close", "err", err)
 			}
 			break
+		}
+
+		// Drop messages from a connection that exceeds its rate instead of
+		// disconnecting, so a brief burst is tolerated but a flood cannot spam
+		// the broadcast.
+		if !c.msgLimiter.Allow() {
+			continue
 		}
 
 		message = bytes.TrimSpace(bytes.ReplaceAll(message, newline, space))
@@ -172,15 +189,30 @@ func (c *Client) writePump() {
 }
 
 // serveWs handles websocket requests from the peer.
-func serveWs(hub *Hub) func(http.ResponseWriter, *http.Request) {
+func serveWs(hub *Hub, conns *connLimiter) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r)
+		// Cap concurrent connections before upgrading so a flood is rejected cheaply.
+		if !conns.acquire(ip) {
+			http.Error(w, "too many connections", http.StatusTooManyRequests)
+			return
+		}
+
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
+			conns.release(ip)
 			log.Error("error upgrading to websocket", "err", err)
 			return
 		}
 
-		client := &Client{hub: hub, conn: conn, send: make(chan []byte, 256)}
+		client := &Client{
+			hub:        hub,
+			conn:       conn,
+			send:       make(chan []byte, 256),
+			ip:         ip,
+			conns:      conns,
+			msgLimiter: rate.NewLimiter(wsMsgPerSec, wsMsgBurst),
+		}
 
 		// Start the pumps, then register: the writePump must be ready to drain the
 		// send channel before the hub can target this client with a broadcast.

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	CertFile    string   `json:"certFile"`
 	KeyFile     string   `json:"keyFile"`
 	TLSHosts    []string `json:"tlsHosts"` // SANs for the self-signed cert generated when secure is true
+	HSTS        bool     `json:"hsts"`     // send Strict-Transport-Security; enable only with a publicly-trusted cert
 }
 
 // LoadConfig reads and parses the JSON config at path. Unlike the previous

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,6 +71,11 @@ only trust it once per device. It is valid for 10 years.
 
 - The container runs read-only and unprivileged (`cap_drop: ALL`, only
   `NET_BIND_SERVICE` to bind :443), with the cert volume and `/tmp` writable.
+- Abuse controls (for public exposure): per-IP HTTP rate limiting, plus per-IP
+  and global caps on concurrent chat connections and a per-connection chat
+  message-rate limit. Set `"hsts": true` in the config once a publicly-trusted
+  cert is in play to send `Strict-Transport-Security` (leave it off on LAN with
+  the self-signed cert).
 - Static assets are minified (HTML/CSS/JS) and served with precomputed
   brotli/zstd/gzip, build-time AVIF/WebP for images, and content-hash ETags
   (`If-None-Match` → 304). `cacheMaxAge` in the config tunes `Cache-Control`.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/quic-go/quic-go v0.60.0
 	github.com/rs/zerolog v1.35.1
 	github.com/tdewolff/minify/v2 v2.24.13
+	golang.org/x/time v0.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -53,5 +53,7 @@ golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
 golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -44,8 +44,14 @@ func fatal(msg string, err error) {
 func buildRouter(cfg Config, hub *Hub, site *staticSite) *mux.Router {
 	r := mux.NewRouter()
 	r.Use(securityHeaders)
+	r.Use(newIPRateLimiter(httpRatePerSec, httpBurst).middleware)
 	if cfg.HTTPS {
 		r.Use(altSvc(cfg.Port))
+	}
+	// HSTS only once a publicly-trusted cert is in play (opt in via config);
+	// browsers ignore it over a self-signed/LAN setup.
+	if cfg.HSTS {
+		r.Use(hsts)
 	}
 
 	// serveAsset serves a named asset (GET/HEAD only), 404ing if absent.
@@ -66,8 +72,9 @@ func buildRouter(cfg Config, hub *Hub, site *staticSite) *mux.Router {
 	}
 
 	// dynamic endpoints
+	conns := newConnLimiter(wsMaxPerIP, wsMaxTotal)
 	r.HandleFunc("/donate/{cryptoname}", handlers.DonateHandler(cfg.CacheMaxAge))
-	r.HandleFunc("/chat/ws", serveWs(hub))
+	r.HandleFunc("/chat/ws", serveWs(hub, conns))
 
 	// pages (pretty URL -> embedded HTML)
 	r.HandleFunc("/", func(w http.ResponseWriter, rq *http.Request) {

--- a/middleware.go
+++ b/middleware.go
@@ -26,6 +26,16 @@ func securityHeaders(next http.Handler) http.Handler {
 	})
 }
 
+// hsts tells browsers to use HTTPS for this host for two years. Only safe with a
+// publicly-trusted cert, so it is gated behind the HSTS config flag and applied
+// only then (see buildRouter).
+func hsts(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // altSvc advertises HTTP/3 availability on the given port via the Alt-Svc header
 // so capable clients upgrade from TCP (h1/h2) to QUIC (h3).
 func altSvc(port string) func(http.Handler) http.Handler {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Abuse-control limits. Generous enough that normal browsing (a page plus its
+// assets, multiplexed over HTTP/2) never trips them, tight enough to stop a
+// flood. The chat is an open broadcast room, so it gets the strictest caps.
+const (
+	httpRatePerSec = 50  // sustained HTTP requests per client IP
+	httpBurst      = 100 // short burst (one page load fans out to many assets)
+	wsMaxPerIP     = 5   // concurrent chat connections per client IP
+	wsMaxTotal     = 200 // concurrent chat connections across all clients
+	wsMsgPerSec    = 2   // chat messages per second per connection
+	wsMsgBurst     = 5   // short message burst per connection
+
+	ipEntryTTL = 10 * time.Minute // evict idle HTTP limiter entries after this
+)
+
+// clientIP returns the request's source IP. The binary terminates connections
+// directly (no proxy), so RemoteAddr is the real client; if it is ever fronted,
+// this is where a trusted X-Forwarded-For would be parsed instead.
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// ipRateLimiter throttles HTTP requests per client IP with a token bucket,
+// sweeping idle entries so the map cannot grow without bound.
+type ipRateLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*ipEntry
+	rate    rate.Limit
+	burst   int
+	stop    chan struct{}
+}
+
+type ipEntry struct {
+	limiter *rate.Limiter
+	seen    time.Time
+}
+
+func newIPRateLimiter(perSec rate.Limit, burst int) *ipRateLimiter {
+	l := &ipRateLimiter{
+		entries: make(map[string]*ipEntry),
+		rate:    perSec,
+		burst:   burst,
+		stop:    make(chan struct{}),
+	}
+	go l.sweepLoop()
+	return l
+}
+
+// Stop ends the background sweeper. The server lets it run for the process
+// lifetime; tests call it so the goroutine exits.
+func (l *ipRateLimiter) Stop() { close(l.stop) }
+
+func (l *ipRateLimiter) allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.entries[ip]
+	if !ok {
+		e = &ipEntry{limiter: rate.NewLimiter(l.rate, l.burst)}
+		l.entries[ip] = e
+	}
+	e.seen = time.Now()
+	return e.limiter.Allow()
+}
+
+func (l *ipRateLimiter) sweepLoop() {
+	t := time.NewTicker(ipEntryTTL)
+	defer t.Stop()
+	for {
+		select {
+		case <-l.stop:
+			return
+		case <-t.C:
+			l.evictIdle(time.Now())
+		}
+	}
+}
+
+// evictIdle drops entries not seen within the TTL ending at now.
+func (l *ipRateLimiter) evictIdle(now time.Time) {
+	cutoff := now.Add(-ipEntryTTL)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for ip, e := range l.entries {
+		if e.seen.Before(cutoff) {
+			delete(l.entries, ip)
+		}
+	}
+}
+
+// middleware rejects requests from an IP that exceeds its rate with 429.
+func (l *ipRateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !l.allow(clientIP(r)) {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// connLimiter caps concurrent websocket connections, both per IP and in total,
+// so the chat hub cannot be exhausted by one client or by sheer numbers.
+type connLimiter struct {
+	mu       sync.Mutex
+	perIP    map[string]int
+	total    int
+	maxPerIP int
+	maxTotal int
+}
+
+func newConnLimiter(maxPerIP, maxTotal int) *connLimiter {
+	return &connLimiter{
+		perIP:    make(map[string]int),
+		maxPerIP: maxPerIP,
+		maxTotal: maxTotal,
+	}
+}
+
+// acquire reserves a connection slot for ip, or returns false when either the
+// per-IP or global cap is reached. Every successful acquire must be paired with
+// a release.
+func (c *connLimiter) acquire(ip string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.total >= c.maxTotal || c.perIP[ip] >= c.maxPerIP {
+		return false
+	}
+	c.perIP[ip]++
+	c.total++
+	return true
+}
+
+func (c *connLimiter) release(ip string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.perIP[ip] > 0 {
+		c.perIP[ip]--
+		c.total--
+		if c.perIP[ip] == 0 {
+			delete(c.perIP, ip)
+		}
+	}
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestIPRateLimiterAllowsBurstThenBlocks(t *testing.T) {
+	l := newIPRateLimiter(1, 3) // 1/s sustained, burst of 3
+	for i := 0; i < 3; i++ {
+		if !l.allow("1.2.3.4") {
+			t.Fatalf("request %d within burst should be allowed", i+1)
+		}
+	}
+	if l.allow("1.2.3.4") {
+		t.Error("request beyond the burst should be blocked")
+	}
+	// A different IP has its own bucket.
+	if !l.allow("5.6.7.8") {
+		t.Error("a different IP should not be throttled")
+	}
+}
+
+func TestIPRateLimiterMiddleware(t *testing.T) {
+	l := newIPRateLimiter(1, 1)
+	h := l.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	first := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "9.9.9.9:1111"
+	h.ServeHTTP(first, req)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first request = %d, want 200", first.Code)
+	}
+
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, req)
+	if second.Code != http.StatusTooManyRequests {
+		t.Errorf("second request = %d, want 429", second.Code)
+	}
+}
+
+func TestConnLimiterCaps(t *testing.T) {
+	c := newConnLimiter(2, 3) // 2 per IP, 3 total
+
+	for i := 0; i < 2; i++ {
+		if !c.acquire("a") {
+			t.Fatalf("connection %d for an IP should be allowed", i+1)
+		}
+	}
+	if c.acquire("a") {
+		t.Error("third connection for the same IP should be rejected (per-IP cap)")
+	}
+
+	if !c.acquire("b") {
+		t.Fatal("a second IP should get a slot (under the global cap)")
+	}
+	if c.acquire("b") {
+		t.Error("connection beyond the global cap should be rejected")
+	}
+
+	// Releasing frees a slot for that IP and the total.
+	c.release("a")
+	if !c.acquire("a") {
+		t.Error("after release the IP should get a slot again")
+	}
+}
+
+// TestIPRateLimiterRefill uses a synctest fake-time bubble to verify the token
+// bucket refills over time, without any real sleeping.
+func TestIPRateLimiterRefill(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		l := newIPRateLimiter(1, 2) // 1 token/sec, burst of 2
+		defer l.Stop()
+
+		for i := 0; i < 2; i++ {
+			if !l.allow("ip") {
+				t.Fatalf("request %d within the burst should be allowed", i+1)
+			}
+		}
+		if l.allow("ip") {
+			t.Fatal("a third immediate request should be blocked")
+		}
+
+		time.Sleep(time.Second) // fake clock advances; one token refills
+		if !l.allow("ip") {
+			t.Error("a request should be allowed after the bucket refills")
+		}
+	})
+}
+
+// TestSweepLoopEvictsIdle drives the real background sweeper with fake time: an
+// idle entry should be evicted once the TTL ticker fires.
+func TestSweepLoopEvictsIdle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		l := newIPRateLimiter(1, 1)
+		defer l.Stop()
+
+		l.allow("ip")
+		time.Sleep(2 * ipEntryTTL) // let the sweep ticker fire past the TTL
+		synctest.Wait()            // let the sweeper finish its tick
+
+		l.mu.Lock()
+		_, present := l.entries["ip"]
+		l.mu.Unlock()
+		if present {
+			t.Error("an idle entry should have been swept")
+		}
+	})
+}
+
+func TestClientIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.7:54321"
+	if got := clientIP(r); got != "203.0.113.7" {
+		t.Errorf("clientIP = %q, want 203.0.113.7", got)
+	}
+}


### PR DESCRIPTION
## What

Hardening for going public. The setup already had good per-connection hygiene (message size cap, read/write deadlines, ping/pong, same-origin check) but nothing throttling *rate* or *per-IP volume*. This adds that.

- **Per-IP HTTP rate limiting** — token bucket (50/s, burst 100), generous enough that normal browsing never trips it. A background sweeper evicts idle entries so the IP map can't grow without bound.
- **Chat websocket caps** — per-IP (`wsMaxPerIP=5`) and global (`wsMaxTotal=200`) limits on concurrent connections, plus a per-connection message-rate limit (2/s, burst 5) that *drops* floods rather than disconnecting (tolerates a brief burst).
- **Config-gated HSTS** — `"hsts": true` sends `Strict-Transport-Security`; left off on LAN with the self-signed cert, flip on once a publicly-trusted cert is in play.

## Testing (the interesting part)

- **`httptest.NewServer` + real `gorilla/websocket` dial** — first end-to-end coverage of the chat path: the connection cap (the 6th dial from one IP gets `429`), an echo round-trip (exercises serveWs + hub + both pumps), and the message-rate drop (a 40-message flood comes back as a throttled few).
- **`testing/synctest`** (new in Go 1.25, you're on 1.26) — the time-dependent limiter logic that real-sleep tests can't cover cleanly: token-bucket **refill** and idle-entry **eviction** driven by the actual background sweeper. The fake clock advances instantly, so the sweep test "sleeps" 20 minutes in 0.00s.

## Verification
- `go test -race ./...` green (incl. the new ws + synctest tests)
- `golangci-lint` clean, `govulncheck` clean
- Manual: sequential browsing all 200; a 50-way parallel burst of 300 returns ~166 `429`

## Note
This is hardening only; it does not open the site to the internet. Public exposure still needs a domain + real cert (ACME) and ingress, tracked separately.