### PR TITLE
Tune config: stdlib router, cache split, deploy and timeout fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 [![CI](https://github.com/aljo242/shmeeload.xyz/actions/workflows/go.yml/badge.svg)](https://github.com/aljo242/shmeeload.xyz/actions/workflows/go.yml) [![go report](https://goreportcard.com/badge/github.com/aljo242/shmeeload.xyz)](https://goreportcard.com/report/github.com/aljo242/shmeeload.xyz) [![license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](./LICENSE)
 
-My personal website. A single self-contained Go server (gorilla/mux +
+My personal website. A single self-contained Go server (stdlib `net/http` routing +
 gorilla/websocket) that embeds the whole site, serves the static assets, and runs the
 shmeechat websocket hub. The frontend is TypeScript compiled to JavaScript at build time.
 
 - The whole site is embedded with `//go:embed`; the binary is the only artifact
 - Text assets minified (HTML/CSS/JS) and served with precomputed brotli/zstd/gzip;
   build-time AVIF/WebP for images (smallest accepted variant wins); content-hash
-  ETags (`If-None-Match` → 304)
+  ETags (`If-None-Match` → 304). HTML is revalidated each load; other assets are cached
+- Per-IP rate limiting and websocket connection/message caps
 - Terminates TLS itself (self-signed cert), speaks HTTP/2, advertises HTTP/3 (QUIC)
 - WebSockets for shmeechat
 - Pages use origin-relative URLs, so the same build works at any host, port, or scheme

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,13 +33,13 @@ phone / laptop  --https://shmee.lan-->  shmeeload binary (:443, TLS + HTTP/2 + H
 From the repo root, sync to the Pi and rebuild:
 
 ```sh
-rsync -az --delete --exclude .git --exclude web_res/node_modules \
+# --chmod=F644 forces world-readable file modes on the Pi. Without it, rsync -a
+# carries the Mac's 0640 mode onto config.local.json, and the unprivileged
+# container user cannot read the :ro bind mount, so it crash-loops with
+# "reading config ...: permission denied".
+rsync -az --delete --chmod=F644 --exclude .git --exclude web_res/node_modules \
   --exclude site/static/js --exclude server \
   ./ cozart@192.168.68.56:/opt/stacks/shmeeload/
-# rsync -a carries the Mac's 0640 mode onto the config; the unprivileged
-# container user must be able to read the :ro bind mount, or it crash-loops
-# with "reading config ...: permission denied".
-ssh cozart@192.168.68.56 'chmod 644 /opt/stacks/shmeeload/deploy/config.local.json'
 ssh cozart@192.168.68.56 'cd /opt/stacks/shmeeload/deploy && docker compose up -d --build'
 ```
 

--- a/deploy/config.local.json
+++ b/deploy/config.local.json
@@ -3,7 +3,7 @@
     "IP": "0.0.0.0",
     "secure": true,
     "debugLog": false,
-    "cacheMaxAge": 0,
+    "cacheMaxAge": 3600,
     "certFile": "/data/cert.pem",
     "keyFile": "/data/key.pem",
     "tlsHosts": ["shmee.lan", "192.168.68.56", "127.0.0.1"]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/HugoSmits86/nativewebp v1.3.0
 	github.com/andybalholm/brotli v1.2.1
 	github.com/gen2brain/avif v0.5.1
-	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.18.6
 	github.com/quic-go/quic-go v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/gen2brain/avif v0.5.1 h1:LQzLsJpWyGlsa4wuZ3D57qEbCiICIK7Yidz5ZPEwzTk=
 github.com/gen2brain/avif v0.5.1/go.mod h1:QgrYqdVE9y40PCfArK9VakcMIpYeDYpZmCSLkW6C1n8=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aljo242/shmeeload.xyz/handlers"
 	"github.com/aljo242/shmeeload.xyz/internal/log"
-	"github.com/gorilla/mux"
 	"github.com/quic-go/quic-go/http3"
 )
 
@@ -41,26 +40,16 @@ func fatal(msg string, err error) {
 // endpoint behind shared middleware. Static assets (/static/*, /files/*,
 // /manifest.json, …) are served straight from the embedded FS; the few pretty
 // page URLs map to their HTML file, and legacy placeholders redirect.
-func buildRouter(cfg Config, hub *Hub, site *staticSite) *mux.Router {
-	r := mux.NewRouter()
-	r.Use(securityHeaders)
-	r.Use(newIPRateLimiter(httpRatePerSec, httpBurst).middleware)
-	if cfg.HTTPS {
-		r.Use(altSvc(cfg.Port))
-	}
-	// HSTS only once a publicly-trusted cert is in play (opt in via config);
-	// browsers ignore it over a self-signed/LAN setup.
-	if cfg.HSTS {
-		r.Use(hsts)
-	}
+//
+// Routing uses the stdlib ServeMux: GET patterns match GET and HEAD (other
+// methods get a 405), "/{$}" matches the root exactly, and "/" is the
+// least-specific catch-all for everything else.
+func buildRouter(cfg Config, hub *Hub, site *staticSite) http.Handler {
+	mux := http.NewServeMux()
 
-	// serveAsset serves a named asset (GET/HEAD only), 404ing if absent.
+	// serveAsset serves a named embedded asset, 404ing if absent.
 	serveAsset := func(name string) http.HandlerFunc {
 		return func(w http.ResponseWriter, rq *http.Request) {
-			if rq.Method != http.MethodGet && rq.Method != http.MethodHead {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
 			if !site.serve(w, rq, name) {
 				http.NotFound(w, rq)
 			}
@@ -73,37 +62,44 @@ func buildRouter(cfg Config, hub *Hub, site *staticSite) *mux.Router {
 
 	// dynamic endpoints
 	conns := newConnLimiter(wsMaxPerIP, wsMaxTotal)
-	r.HandleFunc("/donate/{cryptoname}", handlers.DonateHandler(cfg.CacheMaxAge))
-	r.HandleFunc("/chat/ws", serveWs(hub, conns))
+	mux.HandleFunc("GET /donate/{cryptoname}", handlers.DonateHandler(cfg.CacheMaxAge))
+	mux.HandleFunc("GET /chat/ws", serveWs(hub, conns))
 
 	// pages (pretty URL -> embedded HTML)
-	r.HandleFunc("/", func(w http.ResponseWriter, rq *http.Request) {
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, rq *http.Request) {
 		http.Redirect(w, rq, "/home", http.StatusPermanentRedirect)
 	})
-	r.HandleFunc("/home", page("home.html"))
-	r.HandleFunc("/resume/home", page("resume.html"))
-	r.HandleFunc("/hall-of-art/home", page("shadow.html"))
-	r.HandleFunc("/chat/home", page("chat.html"))
-	r.HandleFunc("/under-construction", page("construction.html"))
+	mux.HandleFunc("GET /home", page("home.html"))
+	mux.HandleFunc("GET /resume/home", page("resume.html"))
+	mux.HandleFunc("GET /hall-of-art/home", page("shadow.html"))
+	mux.HandleFunc("GET /chat/home", page("chat.html"))
+	mux.HandleFunc("GET /under-construction", page("construction.html"))
 
 	// not-yet-built sections
-	r.HandleFunc("/tunes/home", underConstruction)
-	r.HandleFunc("/shop/home", underConstruction)
-	r.HandleFunc("/chat/signup", underConstruction)
-	r.HandleFunc("/chat/signin", underConstruction)
+	mux.HandleFunc("GET /tunes/home", underConstruction)
+	mux.HandleFunc("GET /shop/home", underConstruction)
+	mux.HandleFunc("GET /chat/signup", underConstruction)
+	mux.HandleFunc("GET /chat/signin", underConstruction)
 
 	// everything else is a static asset from the embedded site
-	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, rq *http.Request) {
-		if rq.Method != http.MethodGet && rq.Method != http.MethodHead {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, rq *http.Request) {
 		if !site.serve(w, rq, rq.URL.Path) {
 			http.NotFound(w, rq)
 		}
 	})
 
-	return r
+	// Middleware, applied outermost first: security headers, then per-IP rate
+	// limiting, then the HTTPS-only Alt-Svc and (opt-in) HSTS headers.
+	var h http.Handler = mux
+	if cfg.HSTS {
+		h = hsts(h)
+	}
+	if cfg.HTTPS {
+		h = altSvc(cfg.Port)(h)
+	}
+	h = newIPRateLimiter(httpRatePerSec, httpBurst).middleware(h)
+	h = securityHeaders(h)
+	return h
 }
 
 // initServer loads config and returns a configured (but not yet listening)
@@ -134,9 +130,11 @@ func initServer() (*http.Server, *Hub, Config) {
 		Handler:           buildRouter(cfg, hub, site),
 		ReadTimeout:       15 * time.Second,
 		ReadHeaderTimeout: 15 * time.Second,
-		WriteTimeout:      15 * time.Second,
-		IdleTimeout:       60 * time.Second,
-		MaxHeaderBytes:    1 << 20,
+		// Generous enough to serve the largest original image to a slow client
+		// without truncating; ReadHeaderTimeout is what guards against slowloris.
+		WriteTimeout:   60 * time.Second,
+		IdleTimeout:    60 * time.Second,
+		MaxHeaderBytes: 1 << 20,
 	}
 	return srv, hub, cfg
 }

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func newRouterTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	hub := newHub()
+	go hub.run()
+	site, err := newStaticSite(fstest.MapFS{
+		"home.html":        {Data: []byte("<!doctype html><title>home</title>")},
+		"static/css/x.css": {Data: []byte("body{color:red}")},
+	}, 3600)
+	if err != nil {
+		t.Fatalf("newStaticSite: %v", err)
+	}
+	srv := httptest.NewServer(buildRouter(Config{Port: "0"}, hub, site))
+	t.Cleanup(func() {
+		srv.Close()
+		hub.stop()
+	})
+	return srv
+}
+
+func TestRouting(t *testing.T) {
+	srv := newRouterTestServer(t)
+	// Do not follow redirects, so we can assert the redirect status codes.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	cases := []struct {
+		name, method, path string
+		wantCode           int
+		wantCacheControl   string
+	}{
+		{"root redirects to home", http.MethodGet, "/", http.StatusPermanentRedirect, ""},
+		{"home page, uncached", http.MethodGet, "/home", http.StatusOK, "no-cache"},
+		{"static asset, cached", http.MethodGet, "/static/css/x.css", http.StatusOK, "public, max-age=3600"},
+		{"missing asset", http.MethodGet, "/nope.xyz", http.StatusNotFound, ""},
+		{"non-GET is rejected", http.MethodPost, "/home", http.StatusMethodNotAllowed, ""},
+		{"donate known currency", http.MethodGet, "/donate/btc", http.StatusOK, ""},
+		{"donate unknown currency", http.MethodGet, "/donate/zzz", http.StatusNotFound, ""},
+		{"not-yet-built redirects", http.MethodGet, "/tunes/home", http.StatusTemporaryRedirect, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest(c.method, srv.URL+c.path, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != c.wantCode {
+				t.Errorf("status = %d, want %d", resp.StatusCode, c.wantCode)
+			}
+			if c.wantCacheControl != "" {
+				if got := resp.Header.Get("Cache-Control"); got != c.wantCacheControl {
+					t.Errorf("Cache-Control = %q, want %q", got, c.wantCacheControl)
+				}
+			}
+		})
+	}
+}

--- a/staticsite.go
+++ b/staticsite.go
@@ -68,14 +68,15 @@ type variant struct {
 // compressible types), and WebP/AVIF variants (the build-time "<name>.webp" and
 // "<name>.avif" siblings, when generated for an image).
 type staticAsset struct {
-	contentType string
-	etag        string
-	raw         []byte
-	br          []byte // brotli; nil when not worth it
-	zst         []byte // zstd; nil when not worth it
-	gz          []byte // gzip; nil when not worth it
-	webp        *variant
-	avif        *variant
+	contentType  string
+	etag         string
+	raw          []byte
+	br           []byte // brotli; nil when not worth it
+	zst          []byte // zstd; nil when not worth it
+	gz           []byte // gzip; nil when not worth it
+	webp         *variant
+	avif         *variant
+	cacheControl string
 }
 
 // staticSite serves an embedded file tree with ETag revalidation, minified and
@@ -123,7 +124,12 @@ func newStaticSite(fsys fs.FS, cacheMaxAge int) (*staticSite, error) {
 		// Minify text assets before hashing and compressing, so the ETag and the
 		// br/zstd/gzip variants are all computed from the bytes actually served.
 		b = minifyBytes(m, ct, b)
-		a := &staticAsset{contentType: ct, etag: etagOf(b), raw: b}
+		a := &staticAsset{contentType: ct, etag: etagOf(b), raw: b, cacheControl: s.cacheControl}
+		// HTML carries the page content, which changes between deploys, so it is
+		// always revalidated (cheap via the ETag) rather than cached for a while.
+		if strings.HasPrefix(ct, "text/html") {
+			a.cacheControl = "no-cache"
+		}
 		if compressible(ct) {
 			a.br = smaller(brotliBytes(b), b)
 			a.zst = smaller(zstdBytes(b), b)
@@ -154,7 +160,7 @@ func (s *staticSite) serve(w http.ResponseWriter, r *http.Request, urlPath strin
 	}
 
 	h := w.Header()
-	h.Set("Cache-Control", s.cacheControl)
+	h.Set("Cache-Control", a.cacheControl)
 	h.Add("Vary", "Accept-Encoding")
 
 	// Image negotiation: serve the smallest variant the client accepts. Each


### PR DESCRIPTION
## What

A config-tuning pass across routing, caching, deploy, and timeouts. No new features; same behavior, fewer dependencies, better defaults.

### Drop gorilla/mux for stdlib `net/http.ServeMux`
The app only used `NewRouter` / `HandleFunc` / `PathPrefix` and one path pattern whose capture it didn't even read (the donate handler uses `path.Base`). None of gorilla's actual features (regex constraints, `.Methods`, subrouters, reverse routing) were used. Stdlib (Go 1.22+) covers it exactly:
- `GET` patterns match GET+HEAD; other methods now get a correct **405** (was 400)
- `"/{$}"` is the exact root redirect, `"/"` is the least-specific catch-all
- middleware becomes explicit wrapping instead of `r.Use`

Removes a dependency with no behavior change beyond the cleaner 405.

### Split Cache-Control
The deployed `cacheMaxAge` was **0**, forcing a revalidation round-trip on *every* asset on *every* load. Now:
- **HTML** → `no-cache` (revalidated each load via the ETag, so content edits show immediately)
- **other assets** → `public, max-age=3600`

(Long-term, content-hashed asset filenames would allow `immutable`/1yr; noted for later.)

### Fix the recurring deploy crash-loop
`rsync --chmod=F644` so the bind-mounted config is world-readable on the Pi. `rsync -a` was carrying the Mac's `0640` mode, which the unprivileged container user couldn't read, crash-looping the container with "reading config: permission denied". The manual `chmod` deploy step is gone.

### Bump WriteTimeout 15s -> 60s
So a large original image isn't truncated for a slow client; `ReadHeaderTimeout` still guards slowloris.

## Verification
- `go test -race ./...` green; new `router_test.go` covers redirects, cache headers, 404/405, donate
- `golangci-lint` clean, `govulncheck` clean
- Smoke: root 308->/home, home `no-cache`, css `max-age=3600`, donate 200/404, POST /home 405, missing 404