### PR TITLE
Add external uptime monitor and Permissions-Policy header

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,35 @@
+name: uptime
+
+# External uptime probe for the live site. Runs on a GitHub-hosted runner on
+# purpose (not the self-hosted foundry runner): the point is an outside vantage
+# that can also catch a home-network outage. A failed run emails the repo owner.
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe https://djinntek.space
+        run: |
+          set -e
+          # curl validates the TLS cert by default, so an expired/invalid cert
+          # also fails this. --http2 confirms the negotiated stack works.
+          code=$(curl -sS --http2 --max-time 25 -o /dev/null -w '%{http_code}' https://djinntek.space/home)
+          echo "GET /home -> HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::djinntek.space returned $code (expected 200)"
+            exit 1
+          fi
+      - name: Check www redirect
+        run: |
+          set -e
+          code=$(curl -sS --max-time 25 -o /dev/null -w '%{http_code}' https://www.djinntek.space/home)
+          echo "GET www/home -> HTTP $code"
+          # 301 (redirect to apex) or 200 are both fine; anything else is a problem.
+          case "$code" in
+            200|301|308) ;;
+            *) echo "::error::www.djinntek.space returned $code"; exit 1 ;;
+          esac

--- a/middleware.go
+++ b/middleware.go
@@ -41,6 +41,8 @@ func securityHeaders(next http.Handler) http.Handler {
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Content-Security-Policy", csp)
+		// The site needs none of these powerful features; deny them all.
+		h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), browsing-topics=()")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Post-launch polish.

- **Uptime monitor** (`.github/workflows/uptime.yml`): scheduled every 15 min on a **GitHub-hosted** runner (intentionally external — distinct from the self-hosted CI — so it can catch a home-network outage). Probes `https://djinntek.space/home` for a 200 over HTTP/2 with a valid cert, plus the www redirect. A failed run emails the repo owner.
- **Permissions-Policy** header denying camera/microphone/geolocation/browsing-topics (the site uses none).

Verified: build/test/lint clean. Merging this also serves as the **end-to-end auto-deploy test** — the Pi polls `master` every 5 min, so the new header should appear live shortly after merge without any manual deploy.